### PR TITLE
Add support for linking surface points, snapping drag movement

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+.DS_Store
+target
+

--- a/pom.xml
+++ b/pom.xml
@@ -1,0 +1,77 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <groupId>deadpixel.keystone</groupId>
+  <artifactId>keystone</artifactId>
+  <version>1</version>
+  <packaging>jar</packaging>
+  <build>
+    <sourceDirectory>src</sourceDirectory>
+    <finalName>keystone</finalName>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-dependency-plugin</artifactId>
+        <version>3.0.1</version>
+        <executions>
+          <execution>
+            <id>copy-dependencies</id>
+            <phase>package</phase>
+            <goals>
+              <goal>copy-dependencies</goal>
+            </goals>
+            <configuration>
+              <includeScope>runtime</includeScope>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+    </plugins>
+  </build>
+
+  <name>keystone</name>
+  <url>http://maven.apache.org</url>
+
+  <properties>
+    <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+    <maven.compiler.source>1.8</maven.compiler.source>
+    <maven.compiler.target>1.8</maven.compiler.target>
+  </properties>
+
+  <repositories>
+    <repository>
+      <id>jboss</id>
+      <url>https://repository.jboss.org/nexus/content/repositories/thirdparty-releases/</url>
+    </repository>
+  </repositories>
+
+  <dependencies>
+    <dependency>
+      <groupId>junit</groupId>
+      <artifactId>junit</artifactId>
+      <version>4.12</version>
+      <scope>test</scope>
+    </dependency>
+    <!-- https://mvnrepository.com/artifact/org.processing/core -->
+    <dependency>
+      <groupId>org.processing</groupId>
+      <artifactId>core</artifactId>
+      <version>3.3.5</version>
+      <scope>provided</scope>
+    </dependency>
+    <!-- https://mvnrepository.com/artifact/org.jogamp.jogl/jogl-all -->
+    <dependency>
+      <groupId>org.jogamp.jogl</groupId>
+      <artifactId>jogl-all</artifactId>
+      <version>2.3.2</version>
+      <scope>provided</scope>
+    </dependency>
+    <!-- https://mvnrepository.com/artifact/javax.media/jai-core -->
+    <dependency>
+      <groupId>javax.media</groupId>
+      <artifactId>jai-core</artifactId>
+      <version>1.1.3</version>
+    </dependency>
+  </dependencies>
+</project>

--- a/src/deadpixel/keystone/CornerPinSurface.java
+++ b/src/deadpixel/keystone/CornerPinSurface.java
@@ -1,16 +1,16 @@
 /**
  * Copyright (C) 2009-15 David Bouchard
- * 
+ *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
  * the Free Software Foundation, either version 2 of the License, or
  * (at your option) any later version.
- * 
+ *
  * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU General Public License for more details.
- * 
+ *
  * You should have received a copy of the GNU General Public License
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
@@ -32,9 +32,9 @@ import processing.data.XML;
 /**
  * A simple Corner Pin "keystoned" surface. The surface is a quad mesh that can
  * be skewed to an arbitrary shape by moving its four corners.
- * 
+ *
  * September-2011 Added JAI library for keystone calculus (@edumo)
- * 
+ *
  * March-2013 Added methods to programmatically move the corner points
  */
 public class CornerPinSurface implements Draggable {
@@ -111,7 +111,10 @@ public class CornerPinSurface implements Draggable {
 		this.controlPointColor = 0xFF00FF00;
 	}
 
-	
+	public MeshPoint getMeshPoint(int index) {
+		return mesh[index];
+	}
+
 	// ///////////////
 	// MANUAL MESHPOINT MOVE FUNCTIONS
 	// added by Daniel Wiedemann
@@ -120,8 +123,8 @@ public class CornerPinSurface implements Draggable {
 	// thing if corner points have to be moved across them)
 	// ///////////////
 	/**
-	 * Manually move one of the corners for this surface by some amount. 
-	 * The "corner" parameter should be either: CornerPinSurface.TL, CornerPinSurface.BL, 
+	 * Manually move one of the corners for this surface by some amount.
+	 * The "corner" parameter should be either: CornerPinSurface.TL, CornerPinSurface.BL,
 	 * CornerPinSurface.TR or CornerPinSurface.BR*
 	 */
 	public void moveMeshPointBy(int corner, float moveX, float moveY) {
@@ -210,7 +213,7 @@ public class CornerPinSurface implements Draggable {
 	/**
 	 * This function will give you the position of the mouse in the surface's
 	 * coordinate system.
-	 * 
+	 *
 	 * @return The transformed mouse position
 	 */
 
@@ -431,7 +434,7 @@ public class CornerPinSurface implements Draggable {
 
 	/**
 	 * @invisible
-	 * 
+	 *
 	 *            This moves the surface according to the offset from where the
 	 *            mouse was pressed when selecting the surface.
 	 */
@@ -442,7 +445,7 @@ public class CornerPinSurface implements Draggable {
 
 	/**
 	 * @invisible
-	 * 
+	 *
 	 *            Populates values from an XML object
 	 */
 	void load(XML xml) {

--- a/src/deadpixel/keystone/Keystone.java
+++ b/src/deadpixel/keystone/Keystone.java
@@ -1,16 +1,16 @@
 /**
  * Copyright (C) 2009-15 David Bouchard
- * 
+ *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
  * the Free Software Foundation, either version 2 of the License, or
  * (at your option) any later version.
- * 
+ *
  * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU General Public License for more details.
- * 
+ *
  * You should have received a copy of the GNU General Public License
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
@@ -23,16 +23,16 @@ import processing.core.*;
 import processing.data.XML;
 import processing.event.MouseEvent;
 import processing.opengl.PGraphics3D;
- 
+
 /**
  * This class manages the creation and calibration of keystoned surfaces.
- * 
- * To move and warp surfaces, place the Keystone object in calibrate mode. It catches mouse events and 
+ *
+ * To move and warp surfaces, place the Keystone object in calibrate mode. It catches mouse events and
  * allows you to drag surfaces and control points with the mouse.
  *
- * The Keystone object also provides load/save functionality, once you've calibrated the layout to 
- * your liking. 
- * 
+ * The Keystone object also provides load/save functionality, once you've calibrated the layout to
+ * your liking.
+ *
  * Version: 0.31
  */
 public class Keystone {
@@ -61,19 +61,19 @@ public class Keystone {
 		dragged = null;
 
 		// check the renderer type
-		// issue a warning if we're not in 3D mode 
+		// issue a warning if we're not in 3D mode
 		PGraphics pg = parent.g;
 		if ((pg instanceof PGraphics3D) == false ) {
 			PApplet.println("The keystone library will not work with 2D graphics as the renderer because it relies on texture mapping. " +
 					"Try P3D or OPENGL.");
 		}
-		
+
 		PApplet.println("Keystone " + VERSION);
 	}
 
 	/**
-	 * Creates and registers a new corner pin keystone surface. 
-	 * 
+	 * Creates and registers a new corner pin keystone surface.
+	 *
 	 * @param w width
 	 * @param h height
 	 * @param res resolution (number of tiles per axis)
@@ -86,40 +86,40 @@ public class Keystone {
 	}
 
 	/**
-	 * Starts the calibration mode. Mouse events will be intercepted to drag surfaces 
+	 * Starts the calibration mode. Mouse events will be intercepted to drag surfaces
 	 * and move control points around.
 	 */
 	public void startCalibration() {
 		calibrate = true;
 	}
-	
+
 	/**
 	 * Stops the calibration mode
 	 */
 	public void stopCalibration() {
 		calibrate = false;
 	}
-	
+
 	/**
 	 * Toggles the calibration mode
 	 */
 	public void toggleCalibration() {
 		calibrate = !calibrate;
 	}
-	
+
 	public boolean isCalibrating() {
 		return calibrate;
 	}
 
 	/**
 	 * Returns the version of the library.
-	 * 
+	 *
 	 * @return String
 	 */
 	public String version() {
 		return VERSION;
 	}
-	
+
 	/**
 	 * Saves the layout to an XML file.
 	 */
@@ -150,21 +150,21 @@ public class Keystone {
 				}
 			}
 			root.addChild(surface);
-			
+
 		}
 		/*
 		// write the settings to keystone.xml in the sketch's data folder
 		try {
 			OutputStream stream = parent.createOutput(parent.dataPath(filename));
-			root.save(stream); 
+			root.save(stream);
 		} catch (Exception e) {
 			PApplet.println(e.getStackTrace());
-		}		
+		}
 		*/
 		parent.saveXML(root, filename);
 		PApplet.println("Keystone: layout saved to " + filename);
 	}
-	
+
 	/**
 	 * Saves the current layout into "keystone.xml"
 	 */
@@ -177,7 +177,7 @@ public class Keystone {
 	 */
 	public void load(String filename) {
 		XML root = parent.loadXML(filename);
-		
+
 		/*
 		// Guy's version -- need to figure out why this doesn't work
 		surfaces.clear();
@@ -190,7 +190,7 @@ public class Keystone {
 			surface.load(surfaceEl);
 		}
 		*/
-		
+
 		XML[] surfaceXML = root.getChildren("surface");
 		for (int i=0; i < surfaceXML.length; i++) {
 			surfaces.get(i).load(surfaceXML[i]);
@@ -198,20 +198,22 @@ public class Keystone {
 
 		PApplet.println("Keystone: layout loaded from " + filename);
 	}
-	
+
 	/**
 	 * Loads a saved layout from "keystone.xml"
 	 */
 	public void load() {
 		load("keystone.xml");
 	}
-	
+
+
+	int startX, startY;
 
 	/**
 	 * @invisible
 	 */
 	public void mouseEvent(MouseEvent e) {
-		
+
 		// ignore input events if the calibrate flag is not set
 		if (!calibrate)
 			return;
@@ -223,11 +225,19 @@ public class Keystone {
 
 		case MouseEvent.PRESS:
 			CornerPinSurface top = null;
-			// navigate the list backwards, as to select 
+			// navigate the list backwards, as to select
 			for (int i=surfaces.size()-1; i >= 0; i--) {
 				CornerPinSurface s = surfaces.get(i);
 				dragged = s.select(x, y);
 				if (dragged != null) {
+					if (dragged instanceof MeshPoint) {
+						MeshPoint pt = (MeshPoint) dragged;
+						startX = (int) (pt.x + pt.parent.x);
+						startY = (int) (pt.y + pt.parent.y);
+					} else {
+						startX = x;
+						startY = y;
+					}
 					top = s;
 					break;
 				}
@@ -236,8 +246,8 @@ public class Keystone {
 			if (top != null) {
 				// moved the dragged surface to the beginning of the list
 				// this actually breaks the load/save order.
-				// in the new version, add IDs to surfaces so we can just 
-				// re-load in the right order (or create a separate list 
+				// in the new version, add IDs to surfaces so we can just
+				// re-load in the right order (or create a separate list
 				// for selection/rendering)
 				//int i = surfaces.indexOf(top);
 				//surfaces.remove(i);
@@ -246,8 +256,16 @@ public class Keystone {
 			break;
 
 		case MouseEvent.DRAG:
-			if (dragged != null)
+			if (dragged != null) {
+				if (e.isShiftDown()) {
+					if (Math.abs(x - startX) > Math.abs(y - startY)) {
+						y = startY;
+					} else {
+						x = startX;
+					}
+				}
 				dragged.moveTo(x, y);
+			}
 			break;
 
 		case MouseEvent.RELEASE:

--- a/src/deadpixel/keystone/Keystone.java
+++ b/src/deadpixel/keystone/Keystone.java
@@ -18,6 +18,8 @@
 package deadpixel.keystone;
 
 import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.HashSet;
 import processing.awt.PGraphicsJava2D;
 import processing.core.*;
 import processing.data.XML;
@@ -44,6 +46,7 @@ public class Keystone {
 	ArrayList<CornerPinSurface> surfaces;
 
 	Draggable dragged;
+	HashMap<Draggable, HashSet<MeshPoint>> links;
 
 	// calibration mode is application-wide, so I made this flag static
 	// there should only be one Keystone object around anyway
@@ -59,6 +62,7 @@ public class Keystone {
 
 		surfaces = new ArrayList<CornerPinSurface>();
 		dragged = null;
+		links = new HashMap<Draggable, HashSet<MeshPoint>>();
 
 		// check the renderer type
 		// issue a warning if we're not in 3D mode
@@ -207,6 +211,34 @@ public class Keystone {
 	}
 
 
+	public void link(MeshPoint a, MeshPoint b) {
+		HashSet<MeshPoint> set;
+		set = links.get(a);
+		if (set == null) {
+			set = new HashSet<MeshPoint>();
+			links.put(a, set);
+		}
+		set.add(b);
+		set = links.get(b);
+		if (set == null) {
+			set = new HashSet<MeshPoint>();
+			links.put(b, set);
+		}
+		set.add(a);
+	}
+
+	public void unlink(MeshPoint a, MeshPoint b) {
+		HashSet<MeshPoint> set;
+		set = links.get(a);
+		if (set != null) {
+			set.remove(b);
+		}
+		set = links.get(b);
+		if (set != null) {
+			set.remove(a);
+		}
+	}
+
 	int startX, startY;
 
 	/**
@@ -265,6 +297,12 @@ public class Keystone {
 					}
 				}
 				dragged.moveTo(x, y);
+				HashSet<MeshPoint> set = links.get(dragged);
+				if (set != null) {
+					for (MeshPoint pt: set) {
+						pt.moveTo(x, y);
+					}
+				}
 			}
 			break;
 


### PR DESCRIPTION
Hello,

Not sure if you're interested in updates to this library, but I've added a few quick modifications for an installation I'm working on. It adds checking for a SHIFT modifier during drag to snap the movement to horizontal/vertical movements. And, it adds support for "linking" control points between surfaces so that moving one also moves the other. I can clean it up and add comments a bit more if desired, I just thought I'd send it as is for now to see if you're at all interested...?

Note that there's a potential bug with the CornerPinSurface variables TL/TR/BL/BR- if someone instantiates multiple surfaces with different resolutions, the indices for those points will be different, but since they're static variables, only the most recent values are stored.

Sincerely,
Francis
